### PR TITLE
[BugFixes/Feature] Menu can exit, Game drops to menu, game can pause

### DIFF
--- a/src/States/GameState.cpp
+++ b/src/States/GameState.cpp
@@ -20,7 +20,7 @@ void GameState::input(sf::Event evnt, bool& close, sf::RenderWindow& window, sf:
 		switch (evnt.key.code)
 		{
 		case sf::Keyboard::Escape:
-			pendingChanges.push({ StateChange::REMOVE, StateID::INTRO });
+			pendingChanges.push({ StateChange::REMOVE, StateID::MENU });
 			break;
 		case sf::Keyboard::LShift:
 			timeModifier = 5.0f;

--- a/src/States/GameState.cpp
+++ b/src/States/GameState.cpp
@@ -22,6 +22,9 @@ void GameState::input(sf::Event evnt, bool& close, sf::RenderWindow& window, sf:
 		case sf::Keyboard::Escape:
 			pendingChanges.push({ StateChange::REMOVE, StateID::MENU });
 			break;
+		case sf::Keyboard::BackSpace:
+			timeModifier = 0.0f;
+			break;
 		case sf::Keyboard::LShift:
 			timeModifier = 5.0f;
 			break;
@@ -48,6 +51,7 @@ void GameState::input(sf::Event evnt, bool& close, sf::RenderWindow& window, sf:
 		switch (evnt.key.code)
 		{
 		case sf::Keyboard::LShift:
+		case sf::Keyboard::BackSpace:
 			timeModifier = 1.0f;
 			break;
 		case sf::Keyboard::Space:
@@ -76,7 +80,10 @@ void GameState::input(sf::Event evnt, bool& close, sf::RenderWindow& window, sf:
 }
 
 void GameState::update(sf::Time elapsedTime, bool& close) {
-	elapsedTime /= timeModifier;
+	if (timeModifier != 0.0f)
+		elapsedTime /= timeModifier;
+	else
+		elapsedTime = sf::Time::Zero;
 	// Process Bullets
 	if (!playerBullets.empty()) {
 		for (auto& bullet : playerBullets) {

--- a/src/States/MenuState.cpp
+++ b/src/States/MenuState.cpp
@@ -18,7 +18,7 @@ void MenuState::input(sf::Event evnt, bool& close, sf::RenderWindow& window, sf:
 		if (buttons.at("Play").contains(mousePosF)) {
 			pendingChanges.push({StateChange::ADD, StateID::GAME});
 		} else if (buttons.at("Exit").contains(mousePosF)) {
-			pendingChanges.push({ StateChange::REMOVE, StateID::INTRO });
+			close = true;
 		}	
 		}
 	}


### PR DESCRIPTION
- The menu states exit button no longer jumps back to intro and instead closes the game
- The game now longer skips past menu, dropping all the way to intro and now drops to menu
- While playing, you can now "freeze" the game using the backspace key during gameplay